### PR TITLE
Optimize image by further cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM alpine:3.2
 ENV TERRAFORM_VERSION 0.6.3
 
 RUN apk add --update wget ca-certificates unzip && \
-    wget "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
+    wget -q "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
     apk add --allow-untrusted glibc-2.21-r2.apk && \
-    wget -O /terraform.zip "https://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+    wget -q -O /terraform.zip "https://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
     unzip /terraform.zip -d /bin && \
     apk del --purge wget ca-certificates unzip && \
     rm -rf /var/cache/apk/* glibc-2.21-r2.apk /terraform.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,17 @@ FROM alpine:3.2
 
 ENV TERRAFORM_VERSION 0.6.3
 
-RUN apk add --update bash wget ca-certificates unzip && \
+RUN apk add --update wget ca-certificates unzip && \
     wget "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
     apk add --allow-untrusted glibc-2.21-r2.apk && \
-    rm -rf /var/cache/apk/* glibc-2.21-r2.apk
-
-RUN mkdir /terraform && \
     wget -O /terraform.zip "https://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
-    unzip /terraform.zip -d /terraform && \
-    rm -f /terraform.zip
+    unzip /terraform.zip -d /bin && \
+    apk del --purge wget ca-certificates unzip && \
+    rm -rf /var/cache/apk/* glibc-2.21-r2.apk /terraform.zip
 
 VOLUME ["/data"]
 WORKDIR /data
 
-ENTRYPOINT ["/terraform/terraform"]
+ENTRYPOINT ["/bin/terraform"]
 
 CMD ["--help"]


### PR DESCRIPTION
Remove installed packages that are only need to install but provide
no value at runtime (especially with an entrypoint defined.

Reduce the output from build by making wget quiet.

Leverage /bin for the terraform binaries.
