### PR TITLE
Add git so terraform can download modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.3
 
 ENV TERRAFORM_VERSION 0.6.15
 
-RUN apk add --update wget ca-certificates unzip && \
+RUN apk add --update wget ca-certificates unzip git && \
     wget -q -O /terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
     unzip /terraform.zip -d /bin && \
     apk del --purge wget ca-certificates unzip && \


### PR DESCRIPTION
Otherwise "terraform get" fails with e.g. 

`Error loading Terraform: Error downloading modules: error downloading 'https://github.com/terraform-community-modules/tf_aws_vpc.git': git must be available and on the PATH`
